### PR TITLE
refactor(auth): usar SignedIn y SignedOut en ProtectedRoute

### DIFF
--- a/apps/frontend/src/components/ui/ProtectedRoute.tsx
+++ b/apps/frontend/src/components/ui/ProtectedRoute.tsx
@@ -1,24 +1,19 @@
-import { useUser } from "@clerk/clerk-react";
+import { RedirectToSignIn, SignedIn, SignedOut } from "@clerk/clerk-react";
 import type { ReactNode } from "react";
-import { Navigate } from "react-router";
 
 interface Props {
   children: ReactNode;
 }
 const ProtectedRoute = ({ children }: Props) => {
-  const { isLoaded, isSignedIn } = useUser();
+  return (
+    <>
+      <SignedIn>{children}</SignedIn>
 
-  if (!isLoaded) {
-    return <div>Cargando...</div>;
-  }
-
-  if (!isSignedIn) {
-    return <Navigate to="/" />;
-  }
-
-  // console.log(user.id);
-
-  return children;
+      <SignedOut>
+        <RedirectToSignIn />
+      </SignedOut>
+    </>
+  );
 };
 
 export default ProtectedRoute;


### PR DESCRIPTION
Se refactorizó el componente ProtectedRoute para utilizar los componentes SignedIn 
y SignedOut de Clerk en lugar de condicionales manuales.

Esta mejora reduce la complejidad del código y aprovecha la API declarativa de Clerk 
para proteger rutas de forma más clara y mantenible.
