### PR TITLE
Fix DB path bug for production builds

### DIFF
--- a/apps/backend/CHANGELOG.md
+++ b/apps/backend/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Aligned `userId` type with `UserProfile.id` in `UserVocabulary`.
 
+## [0.4.2] - 2025-06-04
+
+### Fixed
+- Corrected SQLite path to work in production builds
+
 ## [0.4.0] - 2025-05-23
 
 ### Changed

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "ISC",
       "dependencies": {
         "@clerk/express": "^1.4.19",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "main": "index.js",
   "scripts": {
     "test": "echo \"No tests configured\"",

--- a/apps/backend/src/data-source.ts
+++ b/apps/backend/src/data-source.ts
@@ -1,14 +1,17 @@
 import "reflect-metadata";
 import { DataSource } from "typeorm";
+import path from "path";
 
 import { UserProfile } from './entity/UserProfile';
 import { UserProgress } from './entity/UserProgress';
 import { Vocabulary } from './entity/Vocabulary'; // Import the new entity
 import { UserVocabulary } from "./entity/UserVocabulary";
 
+const databasePath = path.join(__dirname, "../src/database.sqlite");
+
 export const AppDataSource = new DataSource({
     type: "sqlite",
-    database: "./src/database.sqlite", // SQLite database file
+    database: databasePath, // SQLite database file
     synchronize: true, // WARNING: synchronize: true is for development only - do not use in production
     logging: false, // Set to true to see SQL logs
     entities: [UserProfile, UserProgress, Vocabulary, UserVocabulary], // Add the new entity here


### PR DESCRIPTION
## Summary
- fix incorrect relative path for the sqlite database so builds work after compilation

## Testing
- `npm run build` *(fails: cannot find module 'dotenv' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683f648477848323bffaa0ff6dc55bc1